### PR TITLE
FIX: Add epicscorelibs lib_path to Python library path - Py38 Compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,15 +66,15 @@ environment:
       PYTHON_ARCH: "64"
       PYTAG: "win_amd64"
 
-    - PYTHON: "C:\\Python38"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "32"
-      PYTAG: "win32"
+    # - PYTHON: "C:\\Python38"
+    #   PYTHON_VERSION: "3.8.x"
+    #   PYTHON_ARCH: "32"
+    #   PYTAG: "win32"
 
-    - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
-      PYTAG: "win_amd64"
+    # - PYTHON: "C:\\Python38-x64"
+    #   PYTHON_VERSION: "3.8.x"
+    #   PYTHON_ARCH: "64"
+    #   PYTAG: "win_amd64"
 
 install:
   - cmd: git submodule update --init --recursive

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,6 +66,16 @@ environment:
       PYTHON_ARCH: "64"
       PYTAG: "win_amd64"
 
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "32"
+      PYTAG: "win32"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+      PYTAG: "win_amd64"
+
 install:
   - cmd: git submodule update --init --recursive
   - ps: "ls \"C:/\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,14 @@ matrix:
       language: python
       services:
         - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 PYVER=cp38-cp38
+      install: docker pull $DOCKER_IMAGE
+      script: docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD "/opt/python/$PYVER/bin/python" /io/cibuild.py docker prepare build manylinux1_x86_64
+
+    - sudo: required
+      language: python
+      services:
+        - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 PRE_CMD=linux32 PYVER=cp27-cp27m
       install: docker pull $DOCKER_IMAGE
       script: docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD "/opt/python/$PYVER/bin/python" /io/cibuild.py docker prepare build manylinux1_i686
@@ -96,6 +104,14 @@ matrix:
       install: docker pull $DOCKER_IMAGE
       script: docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD "/opt/python/$PYVER/bin/python" /io/cibuild.py docker prepare build manylinux1_i686
 
+    - sudo: required
+      language: python
+      services:
+        - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 PRE_CMD=linux32 PYVER=cp38-cp38
+      install: docker pull $DOCKER_IMAGE
+      script: docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD "/opt/python/$PYVER/bin/python" /io/cibuild.py docker prepare build manylinux1_i686
+
     - os: osx
       osx_image: xcode11
       language: generic
@@ -119,6 +135,15 @@ matrix:
     - os: osx
       language: generic
       env: PYTHON=python3 PYVER=3.7 URL=https://www.python.org/ftp/python/3.7.4/python-3.7.4-macosx10.9.pkg
+      install:
+        - ./travis-osx.sh
+        - python3 cibuild.py prepare
+      script:
+        - python3 cibuild.py build macosx_10_9_intel
+
+    - os: osx
+      language: generic
+      env: PYTHON=python3 PYVER=3.8 URL=https://www.python.org/ftp/python/3.8.0/python-3.8.0-macosx10.9.pkg
       install:
         - ./travis-osx.sh
         - python3 cibuild.py prepare

--- a/src/python/epicscorelibs/path/__init__.py
+++ b/src/python/epicscorelibs/path/__init__.py
@@ -30,6 +30,11 @@ if OS_CLASS=='WIN32':
     # windows has nothing like -rpath let alone the $ORIGIN trick
     # so we must add our /lib directory, which contains the .dlls, to %PATH%
     os.environ['PATH'] = '%s%s%s%s'%(os.environ.get('PATH', ''), os.pathsep, lib_path, os.pathsep)
+    try:
+        # Fix for Python 3.8 under Windows. See: https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
+        os.add_dll_directory(lib_path)
+    except Exception:
+        pass
 
 def get_lib(name):
     """Fetch library path by name.


### PR DESCRIPTION
Python 3.8 changed how libraries are searched (See https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew)
Luckily this Pull Request addresses the issue for upstream libraries that depends on epicscorelibs to run by adding the `lib_path` to the `dll_directory` search stack.

I tried to figure out how to properly add Python 3.8 to the test matrix for Travis and AppVeyor but I maybe got it wrong? (It remains to be seen).