### PR TITLE
arm64 fix for epicscorelibs/config.py

### DIFF
--- a/src/python/epicscorelibs/config.py
+++ b/src/python/epicscorelibs/config.py
@@ -60,7 +60,7 @@ def _makeconf():
         elif machine.endswith('86'):
             HA = 'linux-x86'
         else:
-            raise RuntimeError("Unsupported Linkage")
+            raise RuntimeError("Unsupported Linkage: " + machine)
 
     elif osname=='Darwin':
         if machine=='ppc':

--- a/src/python/epicscorelibs/config.py
+++ b/src/python/epicscorelibs/config.py
@@ -55,7 +55,7 @@ def _makeconf():
             HA = 'linux-x86_64'
         elif machine=='ppc':
             HA = 'linux-ppc'
-        elif machine.startswith('arm'):
+        elif machine.startswith('arm') or machine=="aarch64":
             HA = 'linux-arm'
         elif machine.endswith('86'):
             HA = 'linux-x86'


### PR DESCRIPTION
While trying to compile the code in a Docker image `FROM python:3.8`, which uses Debian 10 (buster) as its basis, I came across a **RuntimeError: Unsupported Linkage** exception on the linux/arm64 architecture. I fixed the problem in this branch and would like to ask you to merge the changes in.


Just for reference, my `docker buildx build` command executing `pip install epcscorelibs` throwing the mentioned exception:

```
------                                                                                                                                                                                                                                
 > [linux/arm64 3/4] RUN pip install epicscorelibs:                                                                                                                                                                                   
#9 5.142 Collecting epicscorelibs                                                                                                                                                                                                     
#9 5.255   Downloading epicscorelibs-7.0.3.99.4.0.tar.gz (1.5 MB)                                                                                                                                                                     
#9 6.668   Installing build dependencies: started                                                                                                                                                                                     
#9 18.43   Installing build dependencies: finished with status 'done'                                                                                                                                                                 
#9 18.44   Getting requirements to build wheel: started                                                                                                                                                                               
#9 19.56   Getting requirements to build wheel: finished with status 'error'                                                                                                                                                          
#9 19.56   ERROR: Command errored out with exit status 1:                                                                                                                                                                             
#9 19.56    command: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpp1hxpaxc                                                                     
#9 19.56        cwd: /tmp/pip-install-fuzshge4/epicscorelibs                                                                                                                                                                          
#9 19.56   Complete output (22 lines):                                                                                                                                                                                                
#9 19.56   Traceback (most recent call last):                                                                                                                                                                                         
#9 19.56     File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>                                                                                                                   
#9 19.56       main()
#9 19.56     File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
#9 19.56       json_out['return_val'] = hook(**hook_input['kwargs'])
#9 19.56     File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel
#9 19.56       return hook(config_settings)
#9 19.56     File "/tmp/pip-build-env-gk05qsdq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 146, in get_requires_for_build_wheel
#9 19.56       return self._get_build_requires(
#9 19.56     File "/tmp/pip-build-env-gk05qsdq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 127, in _get_build_requires
#9 19.56       self.run_setup()
#9 19.56     File "/tmp/pip-build-env-gk05qsdq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 248, in run_setup
#9 19.56       super(_BuildMetaLegacyBackend,
#9 19.56     File "/tmp/pip-build-env-gk05qsdq/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 142, in run_setup
#9 19.56       exec(compile(code, __file__, 'exec'), locals())
#9 19.56     File "setup.py", line 23, in <module>
#9 19.56       from epicscorelibs.config import get_config_var
#9 19.56     File "/tmp/pip-install-fuzshge4/epicscorelibs/src/python/epicscorelibs/config.py", line 87, in <module>
#9 19.56       _config = _makeconf()
#9 19.56     File "/tmp/pip-install-fuzshge4/epicscorelibs/src/python/epicscorelibs/config.py", line 63, in _makeconf
#9 19.56       raise RuntimeError("Unsupported Linkage")
#9 19.56   RuntimeError: Unsupported Linkage
#9 19.56   ----------------------------------------
#9 19.56 ERROR: Command errored out with exit status 1: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpp1hxpaxc Check the logs for full command output.
------
```